### PR TITLE
Add support for import and hook name allow-lists

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,47 @@
-module.exports = babel => {
+// matches any hook-like (the default)
+const isHook = /^use[A-Z]/;
+
+// matches only built-in hooks provided by React et al
+const isBuiltInHook = /^use(Callback|Context|DebugValue|Effect|ImperativeHandle|LayoutEffect|Memo|Reducer|Ref|State)$/;
+
+module.exports = (babel, options) => {
+
   const { types: t } = babel;
-  const isHook = /^use[A-Z]/;
+  const onlyBuiltIns = options && options.onlyBuiltIns;
+
+  // if specified, options.lib is a list of libraries that provide hook functions
+  const libs = options && options.lib && (
+    options.lib === true ? ['react', 'preact/hooks'] : [].concat(options.lib)
+  );
 
   return {
     name: "optimize-hook-destructuring",
     visitor: {
       CallExpression(path) {
-        if (isHook.test(path.node.callee.name) && t.isArrayPattern(path.parent.id)) {
-          path.parent.id = t.objectPattern(
-            path.parent.id.elements.map((element, i) =>
-              t.objectProperty(t.numericLiteral(i), element)
-            )
-          );
+        // skip function calls where the return value is not Array-destructured:
+        if (!t.isArrayPattern(path.parent.id)) return;
+
+        // name of the (hook) function being called:
+        const hookName = path.node.callee.name;
+
+        if (libs) {
+          const binding = path.scope.getBinding(hookName);
+          // not an import
+          if (!binding || binding.kind !== 'module') return;
+
+          const specifier = binding.path.parent.source.value;
+          // not a match
+          if (!libs.some(lib => lib === specifier)) return;
         }
+        
+        // only match function calls with names that look like a hook
+        if (!(onlyBuiltIns ? isBuiltInHook : isHook).test(hookName)) return;
+        
+        path.parent.id = t.objectPattern(
+          path.parent.id.elements.map((element, i) =>
+            t.objectProperty(t.numericLiteral(i), element)
+          )
+        );
       }
     }
   };


### PR DESCRIPTION
Add options for controlling which function invocations are considered to be hooks, including import specifier lookup:

```js
["babel-plugin-optimize-hook-destructuring", {
  // only transform known React/Preact hooks:
  onlyBuiltIns: true
}]
```

```js
["babel-plugin-optimize-hook-destructuring", {
  // only transform hook functions imported from "react" or "preact/hooks"
  lib: true
}]
```

```js
["babel-plugin-optimize-hook-destructuring", {
  // only transform hook functions imported from the listed module names
  lib: ["my-awesome-hooks-lib", "react"]
}]
```